### PR TITLE
stack safe

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "no-param-reassign": 2,
     "no-return-assign": 2,
     "no-unused-expressions": 2,
-    "no-use-before-define": 2,
+    "no-use-before-define": [2, "nofunc"],
     "radix": [2, "always"],
     "indent": [2, 2, { "SwitchCase": 1 }],
     "quotes": [2, "double"],

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ install:
   - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/
   - chmod a+x $HOME/purescript
-  - npm install -g bower
   - npm install
-  - bower install
+  - npm run install
 script:
-  - npm run -s build
+  - npm run build
+  - npm run test
+  - npm run bench:start
 after_success:
 - >-
   test $TRAVIS_TAG &&

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,5 @@
+/.*
+!/.gitignore
+!/.travis.yml
+/bower_components/
+/output/

--- a/bench/bower.json
+++ b/bench/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "purescript-eff-aff-bench",
+  "dependencies": {
+    "purescript-minibench": "^2.0.0",
+    "purescript-effect": "safareli/purescript-effect#fast",
+    "purescript-aff": "^5.0.0"
+  },
+  "resolutions": {
+    "purescript-effect": "fast"
+  }
+}

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "scripts": {
+    "clean": "rimraf output && rimraf .pulp-cache",
+    "start": "npm run build && npm run run",
+    "run": "node --expose-gc -e 'require(\"./output/Bench.Main/index.js\").main()'",
+    "build": "eslint src && pulp build -- --censor-lib --strict"
+  },
+  "devDependencies": {
+    "eslint": "^4.19.1",
+    "pulp": "^12.2.0",
+    "purescript-psa": "^0.6.0",
+    "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "bower": "^1.8.8",
+    "purescript": "^0.12.5"
+  }
+}

--- a/bench/src/Bench/Main.js
+++ b/bench/src/Bench/Main.js
@@ -1,0 +1,21 @@
+"use strict";
+
+exports.mkArr = function(){
+  return { count: 0 };
+};
+
+exports.pushToArr = function(xs) {
+  return function() {
+    return function() {
+      xs.count += 1;
+      return xs;
+    };
+  };
+};
+
+exports.log = function(x) {
+  return function(){
+    // eslint-disable-next-line
+    console.log(x);
+  };
+};

--- a/bench/src/Bench/Main.purs
+++ b/bench/src/Bench/Main.purs
@@ -1,0 +1,109 @@
+module Bench.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Aff (Aff, launchAff_)
+import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Unsafe (unsafePerformEffect)
+import Data.Traversable (for_, intercalate)
+import Performance.Minibench (BenchResult, benchWith', withUnits)
+
+
+testApply :: forall m. MonadEffect m => Int -> m Unit
+testApply n' = do
+  arr <- liftEffect mkArr
+  applyLoop (void <<< liftEffect <<< pushToArr arr) n'
+  where
+  applyLoop :: Monad m => (Int -> m Unit) -> Int -> m Unit
+  applyLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (acc <* eff n) (n + 1)
+
+
+testBindRight :: forall m. MonadEffect m => Int -> m Unit
+testBindRight n' = do
+  arr <- liftEffect mkArr
+  bindRightLoop (void <<< liftEffect <<< pushToArr arr) n'
+  where
+  bindRightLoop :: Monad m => (Int -> m Unit)  -> Int -> m Unit
+  bindRightLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (eff (max - n - 1) >>= const acc) (n + 1)
+
+
+testBindLeft :: forall m. MonadEffect m => Int -> m Unit
+testBindLeft n' = do
+  arr <- liftEffect mkArr
+  bindLeftLoop (void <<< liftEffect <<< pushToArr arr) n'
+  where
+  bindLeftLoop :: Monad m => (Int -> m Unit)  -> Int -> m Unit
+  bindLeftLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (acc >>= const (eff n)) (n + 1)
+
+
+testMap :: forall m. MonadEffect m => Int -> m Unit
+testMap n = do
+  arr <- liftEffect mkArr
+  res <- mapLoop n (liftEffect $ pushToArr arr 0)
+  pure unit
+  where
+  mapLoop :: Monad m => Int -> m Int -> m Int
+  mapLoop max i = 
+    if max == 0 
+      then i 
+      else mapLoop (max - 1) (map (_ + 1) i)
+
+
+main :: Effect Unit
+main = do
+  log "<details><summary>benchmark</summary>"
+  log "| bench | type | n | mean | stddev | min | max |"
+  log "| ----- | ---- | - | ---- | ------ | --- | --- |"
+  bench 10 ">>=R" testBindRight testBindRight [100, 1000, 5000]
+  bench 10 ">>=L" testBindLeft testBindLeft [100, 1000, 5000]
+  bench 10 "map" testMap testMap [100, 1000, 5000]
+  bench 10 "apply" testApply testApply [100, 1000, 5000]
+  log "| - | - | - | - | - | - | - |"
+  bench 2 ">>=R" testBindRight testBindRight [10000, 50000, 100000, 1000000]
+  bench 2 ">>=L" testBindLeft testBindLeft [10000, 50000, 100000, 1000000]
+  bench 2 "map" testMap testMap [10000, 50000, 100000, 1000000, 350000, 700000]
+  bench 2 "apply" testApply testApply [10000, 50000, 100000, 1000000]
+  log "</details>"
+
+bench
+  :: Int
+  -> String
+  -> (Int -> Effect Unit)
+  -> (Int -> Aff Unit)
+  -> Array Int
+  -> Effect Unit
+bench n name buildEffect buildAff vals = for_ vals \val -> do 
+  logBench [name <> " build", "Eff", show val] $ benchWith' n \_ -> buildEffect val
+  logBench' identity [name <> " build", "Aff", show val] $ benchWith' n \_ -> buildAff val
+  let eff = liftEffect $ buildEffect val
+  logBench [name <> " run", "Eff", show val] $ benchWith' n \_ -> unsafePerformEffect eff
+  let aff = launchAff_ $ buildAff val
+  logBench' identity [name <> " run", "Aff", show val] $ benchWith' n \_ -> unsafePerformEffect aff
+
+logBench' :: (String -> String) -> Array String -> Effect BenchResult -> Effect Unit
+logBench' f msg benchEffect = do
+  res <- benchEffect
+  let 
+    logStr = intercalate " | " 
+      $ append msg 
+      $ map (f <<< withUnits) [res.mean, res.stdDev, res.min, res.max]
+  log $  "| "  <> logStr <>  " |"
+
+logBench :: Array String -> Effect BenchResult -> Effect Unit
+logBench = logBench' \s -> "**" <> s <> "**"
+
+foreign import data Arr :: Type -> Type
+foreign import mkArr :: forall a. Effect (Arr a)
+foreign import pushToArr :: forall a. Arr a -> a -> Effect a
+foreign import log :: forall a. a -> Effect Unit
+

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "eslint src && pulp build -- --censor-lib --strict"
+    "test": "pulp test",
+    "build": "eslint src && pulp build -- --censor-lib --strict",
+    "install": "bower install && cd bench && bower install",
+    "bench:start": "npm run bench:build && npm run bench:run",
+    "bench:run": "node --expose-gc -e 'require(\"./bench/output/Bench.Main/index.js\").main()'",
+    "bench:build": "cd bench && eslint src && pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
+    "bower": "^1.8.8",
     "eslint": "^4.19.1",
     "pulp": "^12.2.0",
     "purescript-psa": "^0.6.0",

--- a/src/Effect.js
+++ b/src/Effect.js
@@ -1,18 +1,178 @@
 "use strict";
 
-exports.pureE = function (a) {
-  return function () {
-    return a;
+
+/*
+A computation of type `Effect a` in runtime is represented by a function which when
+invoked performs some effect and results some value of type `a`.
+
+With trivial implementation of `Effect` we have an issue with stack usage, as on each `bind`
+you create new function which increases size of stack needed to execute whole computation.
+For example if you write `forever` recursively like this, stack will overflow:
+
+``` purs
+forever :: forall a b. Effect a -> Effect b
+forever f = f *> forever f
+```
+
+Solution to the stack issue is to change runtime representation of Effect from function 
+to some "free like structure" (Defunctionalization), for example if we were to write new
+Effect structure which is stack safe we could do something like this:
+
+``` purs
+data EffectSafe a
+  = Effect (Effect a)
+  | Pure a
+  | exists b. Map (b -> a) (EffectSafe b)
+  | exists b. Apply (EffectSafe b) (EffectSafe (b -> a))
+  | exists b. Bind (b -> EffectSafe a) (EffectSafe b)
+```
+implementing Functor Applicative and Monad instances would be trivial, and instead of
+them constructing new function they create new node of EffectSafe tree structure
+which then needs to be interpreted.
+
+
+We could implement `EffectSafe` in PS but then to get safety benefits everyone should
+start using it and doing FFI on such type will not be as easy as with `Effect` implemented
+with just a function. If we just change runtime representation of the `Effect` that it would
+brake all FFI related code, which we don't want to do.
+
+So we need some way to achieve stack safety such that runtime representation is still a function.
+
+hmmm...
+
+In JS, function is an object, so we can set arbitrary properties on it. i.e. we can use function
+as object, like look up some properties without invoking it. It means we can use function as
+representation of `Effect`, as it was before, but set some properties on it, to be able get
+benefits of the free-ish representation.
+
+So we would assume an `Effect a` to be normal effectful function as before,
+but it could also have `tag` property which could be 'PURE', 'MAP', 'APPLY' or 'BIND',
+depending on the tag, we would expect certain properties to contain certain type of values:
+
+``` js
+Effect a
+  = { Unit -> a }
+  | { Unit -> a, tag: "PURE",   _0 :: a }
+  | { Unit -> a, tag: "MAP",    _0 :: b -> a,        _1 :: Effect  b }
+  | { Unit -> a, tag: "APPLY",  _0 :: Effect b,      _1 :: Effect (b -> a) }
+  | { Unit -> a, tag: "BIND",   _0 :: b -> Effect a, _1 :: Effect  b }
+```
+
+Now hardest thing is to interpret this in stack safe way. but at first let's see
+how `pureE` `mapE` `applyE` `bindE` `runPure` are defined:
+*/
+
+var PURE = "PURE";
+var MAP = "MAP";
+var APPLY = "APPLY";
+var BIND = "BIND";
+var APPLY_FUNC = "APPLY_FUNC";
+
+exports.pureE = function (x) {
+  return mkEff(PURE, x);
+};
+
+exports.mapE = function (f) {
+  return function (effect) {
+    return mkEff(MAP, f, effect);
   };
 };
 
-exports.bindE = function (a) {
-  return function (f) {
-    return function () {
-      return f(a())();
-    };
+exports.applyE = function (effF) {
+  return function (effect) {
+    return mkEff(APPLY, effect, effF);
   };
 };
+
+exports.bindE = function (effect) {
+  return function (f) {
+    return mkEff(BIND, f, effect);
+  };
+};
+
+/*
+
+As you can see this function takes the `tag` and up to 2 values depending on the `tag`.
+in here we create new named function which invokes runEff with itself
+(we give it name so it's easy to identify such functions during debugging)
+then we set `tag`, `_0` and `_1` properties on the function we just constructed
+and return it so the result is basically an object which can also be invoked
+and it then executes `runEff` with itself which tries to evaluate it without
+increasing stack usage.
+
+*/
+function mkEff(tag, _0, _1) {
+  var effect = function $effect() { return runEff($effect); };
+  effect.tag = tag;
+  effect._0 = _0;
+  effect._1 = _1;
+  return effect;
+}
+
+/*
+
+So when this function is called it will take effect which must have the `tag` property on it.
+
+we would set up some variables which are needed for safe evaluation:
+
+* operations - this will be a type aligned sequence of `Operations` which looks like this:
+  ``` purs
+  Operation a b
+    = { tag: "MAP",        _0 :: a -> b }
+    | { tag: "APPLY",      _0 :: Effect a }
+    | { tag: "APPLY_FUNC", _0 :: a -> b }
+    | { tag: "BIND",       _0 :: a -> Effect b }
+  ```
+* effect - initially it's `inputEff` (argument of the `runEff`), it's basically tip of the tree,
+  it will be then updated with other nodes while we are interpreting the structure.
+* res - it will store results of invocations of effects which return results
+* op - it will store current `Operation` which is popped from `operations`
+
+if you look closely at Operation and Effect you would see that they have similar shape.
+this nodes from `Effect` have same representation as `Operation`:
+
+```
+| { Unit -> a, tag: "MAP",    _0 :: b -> a,        _1 :: Effect  b }
+| { Unit -> a, tag: "APPLY",  _0 :: Effect b,      _1 :: Effect (b -> a) }
+| { Unit -> a, tag: "BIND",   _0 :: b -> Effect a, _1 :: Effect  b }
+```
+*/
+
+function runEff(inputEff) {
+  var operations = [];
+  var effect = inputEff;
+  var res;
+  var op;
+  effLoop: for (;;) {
+    if (effect.tag !== undefined) {
+      if (effect.tag === MAP || effect.tag === BIND || effect.tag === APPLY) {
+        operations.push(effect);
+        effect = effect._1 ;
+        continue;
+      }
+      // here `tag === PURE`
+      res = effect._0;
+    } else {
+      res = effect();
+    }
+
+    while ((op = operations.pop())) {
+      if (op.tag === MAP) {
+        res = op._0(res);
+      } else if (op.tag === APPLY_FUNC) {
+        res = op._0(res);
+      } else if (op.tag === APPLY) {
+        effect = op._0;
+        operations.push({ tag: APPLY_FUNC, _0: res });
+        continue effLoop;
+      } else { // op.tag === BIND
+        effect = op._0(res);
+        continue effLoop;
+      }
+    }
+    return res;
+  }
+}
 
 exports.untilE = function (f) {
   return function () {

--- a/src/Effect.purs
+++ b/src/Effect.purs
@@ -16,10 +16,14 @@ import Control.Apply (lift2)
 foreign import data Effect :: Type -> Type
 
 instance functorEffect :: Functor Effect where
-  map = liftA1
+  map = mapE
+
+foreign import mapE :: forall a b. (a -> b) -> Effect a -> Effect b
 
 instance applyEffect :: Apply Effect where
-  apply = ap
+  apply = applyE
+
+foreign import applyE :: forall a b. Effect (a -> b) -> Effect a -> Effect b
 
 instance applicativeEffect :: Applicative Effect where
   pure = pureE

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,0 +1,56 @@
+"use strict";
+
+exports.mkArr = function(){
+  return [];
+};
+
+exports.unArr = function(xs){
+  return xs.slice(0);
+};
+
+exports.pushToArr = function(xs) {
+  return function(x) {
+    return function() {
+      xs.push(x);
+      return x;
+    };
+  };
+};
+
+exports.assert = function(isOk) {
+  return function(msg) {
+    return function() {
+      if (isOk == false) {
+        throw new Error("assertion failed: " + msg);
+      };
+    };
+  };
+};
+
+exports.naturals = function(n) {
+  var res = [];
+  for (var index = 0; index < n; index++) {
+    res[index] = index;
+  }
+  return res;
+};
+
+exports.log = function(x) {
+  return function(){
+    console.log(x)
+  }
+};
+
+
+exports.time = function(x) {
+  return function(){
+    console.time(x)
+  }
+};
+
+
+exports.timeEnd = function(x) {
+  return function(){
+    console.timeEnd(x)
+  }
+};

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,0 +1,93 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Control.Apply (lift2)
+
+testLift2 :: Effect Unit
+testLift2 = do
+  arr <- mkArr
+  res <- (pushToArr arr 1) `lift2 (+)` (pushToArr arr 2)
+  res' <- (pure 1) `lift2 (+)` (pure 2)
+  assert ([1, 2] == unArr arr) "lift2 1/3"
+  assert (3 == res') "lift2 2/3"
+  assert (3 == res) "lift2 3/3"
+
+
+testApply :: Int -> Effect Unit
+testApply n' = do
+  arr <-  mkArr
+  applyLoop (void <<< pushToArr arr) n'
+  assert (naturals n' == unArr arr) $ "apply " <> show n'
+  where
+  applyLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (acc <* eff n) (n + 1)
+
+
+
+testBindRight :: Int -> Effect Unit
+testBindRight n' = do
+  arr <-  mkArr
+  bindRightLoop (void <<< pushToArr arr) n'
+  assert (naturals n' == unArr arr) $ "bind right " <> show n'
+  where
+  bindRightLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (eff (max - n - 1) >>= const acc) (n + 1)
+
+
+testBindLeft :: Int -> Effect Unit
+testBindLeft n' = do
+  arr <-  mkArr
+  bindLeftLoop (void <<< pushToArr arr) n'
+  assert (naturals n' == unArr arr) $ "bind left " <> show n'
+  where
+  bindLeftLoop eff max = go (pure unit) 0
+    where 
+    go acc n | n == max = acc
+    go acc n = go (acc >>= const (eff n)) (n + 1)
+
+
+testMap :: Int -> Effect Unit
+testMap n = do
+  arr <- mkArr
+  res <- mapLoop n (pushToArr arr 0)
+  assert (res == n) $ "map " <> show n
+  assert ([0] == unArr arr) $ "map" 
+  where
+  mapLoop max i = 
+    if max == 0 
+      then i 
+      else mapLoop (max - 1) (map (_ + 1) i)
+
+
+main :: Effect Unit
+main = do
+  test "testLift2" $ testLift2
+  test "testBindRight" $ testBindRight 1000000
+  test "testBindLeft" $ testMap 1000000
+  test "testMap" $ testMap 5000000
+  test "testApply" $ testApply 1000000
+  where
+  test msg eff = do
+    time msg
+    eff
+    timeEnd msg
+
+
+foreign import data Arr :: Type -> Type
+
+
+foreign import mkArr :: forall a. Effect (Arr a)
+foreign import pushToArr :: forall a. Arr a -> a -> Effect a
+foreign import assert :: Boolean -> String -> Effect Unit
+foreign import log :: forall a. a -> Effect Unit
+foreign import unArr :: forall a. Arr a -> Array a
+foreign import naturals :: Int -> Array Int
+
+foreign import time :: String -> Effect Unit
+foreign import timeEnd :: String -> Effect Unit


### PR DESCRIPTION
fix #9 

updated work made in https://github.com/purescript-deprecated/purescript-eff/pull/31 

<details><summary>benchmark</summary>

| bench | type | n | mean | stddev | min | max |
| ----- | ---- | - | ---- | ------ | --- | --- |
| >>=R build | Eff | 100 | **43.32 μs** | **129.40 μs** | **881.00 ns** | **411.46 μs** |
| >>=R build | Aff | 100 | 15.08 μs | 39.84 μs | 1.84 μs | 128.39 μs |
| >>=R run | Eff | 100 | **211.71 μs** | **198.96 μs** | **137.53 μs** | **776.26 μs** |
| >>=R run | Aff | 100 | 354.32 μs | 368.47 μs | 230.62 μs | 1.40 ms |
| >>=R build | Eff | 1000 | **2.71 μs** | **2.18 μs** | **1.51 μs** | **8.61 μs** |
| >>=R build | Aff | 1000 | 2.54 μs | 1.99 μs | 1.35 μs | 8.16 μs |
| >>=R run | Eff | 1000 | **1.72 ms** | **1.14 ms** | **379.97 μs** | **3.76 ms** |
| >>=R run | Aff | 1000 | 1.94 ms | 1.04 ms | 988.37 μs | 4.46 ms |
| >>=R build | Eff | 5000 | **1.65 μs** | **1.98 μs** | **893.00 ns** | **7.24 μs** |
| >>=R build | Aff | 5000 | 1.55 μs | 1.53 μs | 848.00 ns | 5.85 μs |
| >>=R run | Eff | 5000 | **4.71 ms** | **2.58 ms** | **1.33 ms** | **8.47 ms** |
| >>=R run | Aff | 5000 | 5.84 ms | 3.66 ms | 2.15 ms | 11.92 ms |
| >>=L build | Eff | 100 | **29.42 μs** | **87.50 μs** | **764.00 ns** | **278.34 μs** |
| >>=L build | Aff | 100 | 2.08 μs | 2.01 μs | 1.26 μs | 7.75 μs |
| >>=L run | Eff | 100 | **117.08 μs** | **155.40 μs** | **63.07 μs** | **559.29 μs** |
| >>=L run | Aff | 100 | 168.60 μs | 20.01 μs | 150.76 μs | 211.12 μs |
| >>=L build | Eff | 1000 | **2.16 μs** | **1.95 μs** | **1.30 μs** | **7.59 μs** |
| >>=L build | Aff | 1000 | 1.44 μs | 1.70 μs | 784.00 ns | 6.25 μs |
| >>=L run | Eff | 1000 | **597.75 μs** | **241.14 μs** | **288.23 μs** | **1.01 ms** |
| >>=L run | Aff | 1000 | 1.48 ms | 423.76 μs | 989.80 μs | 2.39 ms |
| >>=L build | Eff | 5000 | **1.58 μs** | **2.03 μs** | **766.00 ns** | **7.33 μs** |
| >>=L build | Aff | 5000 | 1.27 μs | 1.25 μs | 763.00 ns | 4.78 μs |
| >>=L run | Eff | 5000 | **3.89 ms** | **2.37 ms** | **1.32 ms** | **7.66 ms** |
| >>=L run | Aff | 5000 | 4.45 ms | 2.94 ms | 1.81 ms | 10.19 ms |
| map build | Eff | 100 | **13.74 μs** | **38.48 μs** | **730.00 ns** | **123.11 μs** |
| map build | Aff | 100 | 1.30 μs | 1.34 μs | 772.00 ns | 5.06 μs |
| map run | Eff | 100 | **143.35 μs** | **208.15 μs** | **41.52 μs** | **722.96 μs** |
| map run | Aff | 100 | 125.66 μs | 43.96 μs | 91.94 μs | 221.56 μs |
| map build | Eff | 1000 | **1.37 μs** | **1.58 μs** | **745.00 ns** | **5.84 μs** |
| map build | Aff | 1000 | 9.88 μs | 24.13 μs | 1.11 μs | 78.02 μs |
| map run | Eff | 1000 | **340.58 μs** | **123.69 μs** | **214.02 μs** | **561.88 μs** |
| map run | Aff | 1000 | 712.70 μs | 321.60 μs | 389.96 μs | 1.24 ms |
| map build | Eff | 5000 | **1.85 μs** | **1.61 μs** | **1.20 μs** | **6.41 μs** |
| map build | Aff | 5000 | 5.35 μs | 11.37 μs | 1.05 μs | 37.25 μs |
| map run | Eff | 5000 | **1.18 ms** | **882.39 μs** | **620.83 μs** | **3.39 ms** |
| map run | Aff | 5000 | 3.82 ms | 2.50 ms | 1.63 ms | 8.60 ms |
| apply build | Eff | 100 | **18.52 μs** | **52.71 μs** | **754.00 ns** | **168.43 μs** |
| apply build | Aff | 100 | 9.30 μs | 22.66 μs | 1.04 μs | 73.25 μs |
| apply run | Eff | 100 | **249.50 μs** | **188.70 μs** | **157.87 μs** | **764.58 μs** |
| apply run | Aff | 100 | 956.74 μs | 2.05 ms | 204.81 μs | 6.79 ms |
| apply build | Eff | 1000 | **1.95 μs** | **1.66 μs** | **1.29 μs** | **6.65 μs** |
| apply build | Aff | 1000 | 9.34 μs | 20.20 μs | 1.76 μs | 66.05 μs |
| apply run | Eff | 1000 | **1.00 ms** | **363.33 μs** | **569.89 μs** | **1.62 ms** |
| apply run | Aff | 1000 | 3.81 ms | 1.94 ms | 1.70 ms | 7.48 ms |
| apply build | Eff | 5000 | **1.32 μs** | **1.38 μs** | **741.00 ns** | **5.22 μs** |
| apply build | Aff | 5000 | 4.38 μs | 7.95 μs | 1.03 μs | 26.50 μs |
| apply run | Eff | 5000 | **4.23 ms** | **1.94 ms** | **2.23 ms** | **7.67 ms** |
| apply run | Aff | 5000 | 11.20 ms | 2.57 ms | 9.25 ms | 18.19 ms |
| - | - | - | - | - | - | - |
| >>=R build | Eff | 10000 | **3.33 μs** | **2.78 μs** | **1.36 μs** | **5.29 μs** |
| >>=R build | Aff | 10000 | 34.65 μs | 30.98 μs | 12.75 μs | 56.56 μs |
| >>=R run | Eff | 10000 | **7.57 ms** | **3.30 ms** | **5.24 ms** | **9.91 ms** |
| >>=R run | Aff | 10000 | 17.67 ms | 41.47 μs | 17.64 ms | 17.70 ms |
| >>=R build | Eff | 50000 | **8.73 μs** | **8.88 μs** | **2.46 μs** | **15.01 μs** |
| >>=R build | Aff | 50000 | 24.72 μs | 22.66 μs | 8.70 μs | 40.74 μs |
| >>=R run | Eff | 50000 | **109.05 ms** | **36.31 ms** | **83.38 ms** | **134.73 ms** |
| >>=R run | Aff | 50000 | 204.59 ms | 73.84 ms | 152.38 ms | 256.80 ms |
| >>=R build | Eff | 100000 | **19.40 μs** | **9.01 μs** | **13.03 μs** | **25.77 μs** |
| >>=R build | Aff | 100000 | 81.61 μs | 10.48 μs | 74.20 μs | 89.03 μs |
| >>=R run | Eff | 100000 | **306.49 ms** | **127.54 ms** | **216.31 ms** | **396.67 ms** |
| >>=R run | Aff | 100000 | 419.11 ms | 81.90 ms | 361.20 ms | 477.02 ms |
| >>=R build | Eff | 1000000 | **6.00 μs** | **5.19 μs** | **2.33 μs** | **9.67 μs** |
| >>=R build | Aff | 1000000 | 34.99 μs | 38.85 μs | 7.52 μs | 62.47 μs |
| >>=R run | Eff | 1000000 | **4.13 s** | **2.18 s** | **2.59 s** | **5.67 s** |
| >>=R run | Aff | 1000000 | 4.28 s | 573.69 ms | 3.88 s | 4.69 s |
| >>=L build | Eff | 10000 | **6.52 μs** | **6.44 μs** | **1.97 μs** | **11.08 μs** |
| >>=L build | Aff | 10000 | 33.31 μs | 35.44 μs | 8.25 μs | 58.36 μs |
| >>=L run | Eff | 10000 | **22.02 ms** | **4.88 ms** | **18.56 ms** | **25.47 ms** |
| >>=L run | Aff | 10000 | 30.54 ms | 18.12 ms | 17.73 ms | 43.36 ms |
| >>=L build | Eff | 50000 | **4.70 μs** | **3.77 μs** | **2.03 μs** | **7.36 μs** |
| >>=L build | Aff | 50000 | 23.86 μs | 19.90 μs | 9.78 μs | 37.93 μs |
| >>=L run | Eff | 50000 | **110.11 ms** | **31.00 ms** | **88.20 ms** | **132.03 ms** |
| >>=L run | Aff | 50000 | 242.86 ms | 92.22 ms | 177.65 ms | 308.07 ms |
| >>=L build | Eff | 100000 | **11.27 μs** | **7.01 μs** | **6.31 μs** | **16.22 μs** |
| >>=L build | Aff | 100000 | 42.01 μs | 48.56 μs | 7.67 μs | 76.34 μs |
| >>=L run | Eff | 100000 | **324.61 ms** | **107.09 ms** | **248.89 ms** | **400.34 ms** |
| >>=L run | Aff | 100000 | 447.80 ms | 86.00 ms | 386.99 ms | 508.62 ms |
| >>=L build | Eff | 1000000 | **7.66 μs** | **8.06 μs** | **1.96 μs** | **13.36 μs** |
| >>=L build | Aff | 1000000 | 70.69 μs | 77.81 μs | 15.67 μs | 125.72 μs |
| >>=L run | Eff | 1000000 | **3.18 s** | **774.65 ms** | **2.64 s** | **3.73 s** |
| >>=L run | Aff | 1000000 | 11.36 s | 8.53 s | 5.33 s | 17.40 s |
| map build | Eff | 10000 | **7.29 μs** | **5.64 μs** | **3.31 μs** | **11.28 μs** |
| map build | Aff | 10000 | 46.05 μs | 46.44 μs | 13.21 μs | 78.89 μs |
| map run | Eff | 10000 | **5.24 ms** | **217.28 μs** | **5.08 ms** | **5.39 ms** |
| map run | Aff | 10000 | 15.01 ms | 12.58 ms | 6.12 ms | 23.91 ms |
| map build | Eff | 50000 | **4.32 μs** | **3.01 μs** | **2.19 μs** | **6.45 μs** |
| map build | Aff | 50000 | 16.23 μs | 14.19 μs | 6.20 μs | 26.26 μs |
| map run | Eff | 50000 | **14.28 ms** | **2.40 ms** | **12.58 ms** | **15.97 ms** |
| map run | Aff | 50000 | 61.19 ms | 23.59 ms | 44.51 ms | 77.87 ms |
| map build | Eff | 100000 | **4.27 μs** | **3.30 μs** | **1.93 μs** | **6.60 μs** |
| map build | Aff | 100000 | 40.82 μs | 42.18 μs | 11.00 μs | 70.65 μs |
| map run | Eff | 100000 | **51.75 ms** | **1.39 ms** | **50.77 ms** | **52.73 ms** |
| map run | Aff | 100000 | 175.20 ms | 15.22 ms | 164.44 ms | 185.96 ms |
| map build | Eff | 1000000 | **5.06 μs** | **3.95 μs** | **2.27 μs** | **7.86 μs** |
| map build | Aff | 1000000 | 28.48 μs | 26.48 μs | 9.75 μs | 47.21 μs |
| map run | Eff | 1000000 | **1.30 s** | **619.66 ms** | **857.32 ms** | **1.73 s** |
| map run | Aff | 1000000 | 2.00 s | 305.70 ms | 1.78 s | 2.21 s |
| map build | Eff | 350000 | **6.09 μs** | **6.00 μs** | **1.84 μs** | **10.33 μs** |
| map build | Aff | 350000 | 75.70 μs | 18.64 μs | 62.52 μs | 88.88 μs |
| map run | Eff | 350000 | **324.03 ms** | **61.57 ms** | **280.49 ms** | **367.57 ms** |
| map run | Aff | 350000 | 644.66 ms | 69.64 ms | 595.41 ms | 693.90 ms |
| map build | Eff | 700000 | **4.85 μs** | **4.71 μs** | **1.52 μs** | **8.18 μs** |
| map build | Aff | 700000 | 53.11 μs | 50.24 μs | 17.59 μs | 88.64 μs |
| map run | Eff | 700000 | **607.53 ms** | **155.39 ms** | **497.65 ms** | **717.41 ms** |
| map run | Aff | 700000 | 1.76 s | 620.00 ms | 1.32 s | 2.20 s |
| apply build | Eff | 10000 | **5.55 μs** | **5.87 μs** | **1.40 μs** | **9.70 μs** |
| apply build | Aff | 10000 | 114.71 μs | 118.45 μs | 30.95 μs | 198.46 μs |
| apply run | Eff | 10000 | **9.93 ms** | **2.98 ms** | **7.82 ms** | **12.03 ms** |
| apply run | Aff | 10000 | 59.19 ms | 131.00 μs | 59.10 ms | 59.28 ms |
| apply build | Eff | 50000 | **5.21 μs** | **4.50 μs** | **2.03 μs** | **8.39 μs** |
| apply build | Aff | 50000 | 43.94 μs | 46.97 μs | 10.73 μs | 77.15 μs |
| apply run | Eff | 50000 | **143.75 ms** | **57.67 ms** | **102.97 ms** | **184.52 ms** |
| apply run | Aff | 50000 | 384.62 ms | 41.34 ms | 355.39 ms | 413.86 ms |
| apply build | Eff | 100000 | **6.90 μs** | **7.03 μs** | **1.93 μs** | **11.86 μs** |
| apply build | Aff | 100000 | 59.84 μs | 25.76 μs | 41.62 μs | 78.05 μs |
| apply run | Eff | 100000 | **335.42 ms** | **67.59 ms** | **287.63 ms** | **383.21 ms** |
| apply run | Aff | 100000 | 846.18 ms | 192.05 ms | 710.38 ms | 981.98 ms |
| apply build | Eff | 1000000 | **7.54 μs** | **7.68 μs** | **2.11 μs** | **12.97 μs** |
| apply build | Aff | 1000000 | 55.95 μs | 62.42 μs | 11.81 μs | 100.09 μs |
| apply run | Eff | 1000000 | **7.13 s** | **4.00 s** | **4.30 s** | **9.95 s** |
| apply run | Aff | 1000000 | 25.64 s | 1.79 s | 24.37 s | 26.90 s |

</details>