### PR TITLE
Remove `return {}` from FFI functions

### DIFF
--- a/src/Effect.js
+++ b/src/Effect.js
@@ -17,7 +17,6 @@ exports.bindE = function (a) {
 exports.untilE = function (f) {
   return function () {
     while (!f());
-    return {};
   };
 };
 
@@ -27,7 +26,6 @@ exports.whileE = function (f) {
       while (f()) {
         a();
       }
-      return {};
     };
   };
 };


### PR DESCRIPTION
See [this Slack thread](https://functionalprogramming.slack.com/archives/C717K38CE/p1594507158478300) for context.