### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Effect.purs
+++ b/src/Effect.purs
@@ -15,6 +15,8 @@ import Control.Apply (lift2)
 -- | eventually produces a value of the type `Int` when it finishes.
 foreign import data Effect :: Type -> Type
 
+type role Effect representational
+
 instance functorEffect :: Functor Effect where
   map = liftA1
 

--- a/src/Effect/Uncurried.purs
+++ b/src/Effect/Uncurried.purs
@@ -136,15 +136,44 @@ import Data.Monoid (class Monoid, class Semigroup, mempty, (<>))
 import Effect (Effect)
 
 foreign import data EffectFn1 :: Type -> Type -> Type
+
+type role EffectFn1 representational representational
+
 foreign import data EffectFn2 :: Type -> Type -> Type -> Type
+
+type role EffectFn2 representational representational representational
+
 foreign import data EffectFn3 :: Type -> Type -> Type -> Type -> Type
+
+type role EffectFn3 representational representational representational representational
+
 foreign import data EffectFn4 :: Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn4 representational representational representational representational representational
+
 foreign import data EffectFn5 :: Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn5 representational representational representational representational representational representational
+
 foreign import data EffectFn6 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn6 representational representational representational representational representational representational representational
+
 foreign import data EffectFn7 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn7 representational representational representational representational representational representational representational representational
+
 foreign import data EffectFn8 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn8 representational representational representational representational representational representational representational representational representational
+
 foreign import data EffectFn9 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn9 representational representational representational representational representational representational representational representational representational representational
+
 foreign import data EffectFn10 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+
+type role EffectFn10 representational representational representational representational representational representational representational representational representational representational representational
 
 foreign import mkEffectFn1 :: forall a r.
   (a -> Effect r) -> EffectFn1 a r


### PR DESCRIPTION
This allows terms of type `Effect a` to be coerced to type `Effect b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under effects for instance. Ditto for all the uncurried effectful functions types.