### PR TITLE
Export MonadEffect from Effect

### DIFF
--- a/src/Effect.purs
+++ b/src/Effect.purs
@@ -3,6 +3,8 @@
 -- | computations, while at the same time generating efficient JavaScript.
 module Effect
   ( Effect
+  , class MonadEffect
+  , liftEffect
   , untilE, whileE, forE, foreachE
   ) where
 
@@ -45,6 +47,20 @@ instance semigroupEffect :: Semigroup a => Semigroup (Effect a) where
 -- | `pure mempty`.
 instance monoidEffect :: Monoid a => Monoid (Effect a) where
   mempty = pureE mempty
+
+-- | The `MonadEffect` class captures those monads which support native effects.
+-- |
+-- | Instances are provided for `Effect` itself, and the standard monad
+-- | transformers.
+-- |
+-- | `liftEffect` can be used in any appropriate monad transformer stack to lift an
+-- | action of type `Effect a` into the monad.
+-- |
+class Monad m <= MonadEffect m where
+  liftEffect :: forall a. Effect a -> m a
+
+instance monadEffectEffect :: MonadEffect Effect where
+  liftEffect = identity
 
 -- | Loop until a condition becomes `true`.
 -- |

--- a/src/Effect/Class.purs
+++ b/src/Effect/Class.purs
@@ -1,19 +1,12 @@
-module Effect.Class where
+module Effect.Class
+  ( module MonadEffect
+  , liftEffect
+  ) where
 
-import Control.Category (identity)
-import Control.Monad (class Monad)
-import Effect (Effect)
+import Effect (class MonadEffect, Effect)
+import Effect (class MonadEffect) as MonadEffect
+import Effect (liftEffect) as Effect
+import Prim.TypeError (class Warn, Text)
 
--- | The `MonadEffect` class captures those monads which support native effects.
--- |
--- | Instances are provided for `Effect` itself, and the standard monad
--- | transformers.
--- |
--- | `liftEffect` can be used in any appropriate monad transformer stack to lift an
--- | action of type `Effect a` into the monad.
--- |
-class Monad m <= MonadEffect m where
-  liftEffect :: forall a. Effect a -> m a
-
-instance monadEffectEffect :: MonadEffect Effect where
-  liftEffect = identity
+liftEffect :: forall a m. MonadEffect m => Warn (Text "'Effect.Class.liftEffect' is deprecated, use Effect.liftEffect instead") => Effect a -> m a
+liftEffect = Effect.liftEffect


### PR DESCRIPTION
This pull request addresses the first part of https://github.com/purescript/purescript-effect/issues/19, defining MonadEffect in Effect and deprecating Effect.Class.liftEffect.

We cannot warn when MonadEffect is imported from Monad.Class though, so perhaps we should remove Effect.Class altogether?