### PR TITLE
Add withGlobalLock

### DIFF
--- a/src/Effect.js
+++ b/src/Effect.js
@@ -51,3 +51,7 @@ exports.foreachE = function (as) {
     };
   };
 };
+
+exports.withGlobalLock = function (e) {
+  return e;
+};

--- a/src/Effect.purs
+++ b/src/Effect.purs
@@ -3,7 +3,7 @@
 -- | computations, while at the same time generating efficient JavaScript.
 module Effect
   ( Effect
-  , untilE, whileE, forE, foreachE
+  , untilE, whileE, forE, foreachE, withGlobalLock
   ) where
 
 import Prelude
@@ -70,3 +70,9 @@ foreign import forE :: Int -> Int -> (Int -> Effect Unit) -> Effect Unit
 -- | `foreachE xs f` runs the computation returned by the function `f` for each
 -- | of the inputs `xs`.
 foreign import foreachE :: forall a. Array a -> (a -> Effect Unit) -> Effect Unit
+
+-- | Run the effect exclusively by acquiring a global runtime lock.
+-- |
+-- | On javascript, since javascript is single threaded, this simply returns
+-- | the provided effect.
+foreign import withGlobalLock :: forall a. Effect a -> Effect a


### PR DESCRIPTION
When working with purescript with a JS backend, it is sometimes useful to take advantage of the single threaded runtime. That is, binding effects knowing that no external threads can run, and that the sequence of effects will run in isolation.

However, this assumption is not always true on other purescript backends.

So this change adds a way to mark an Effect, at least in source code as needing to run exclusively from other threads.

On JS this simply returns the provided effect since JS is single threaded and doesn't really allow other simultaneous threads to run.