### PR TITLE
Add EffectFn0, mkEffectFn0, and runEffectFn0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+  - Added `EffectFn0`, `mkEffectFn0`, and `runEffectFn0` (#31)
 
 Bugfixes:
 

--- a/src/Effect/Uncurried.js
+++ b/src/Effect/Uncurried.js
@@ -1,3 +1,9 @@
+export const mkEffectFn0 = function mkEffectFn0(fn) {
+  return function() {
+    return fn()();
+  };
+};
+
 export const mkEffectFn1 = function mkEffectFn1(fn) {
   return function(x) {
     return fn(x)();
@@ -55,6 +61,12 @@ export const mkEffectFn9 = function mkEffectFn9(fn) {
 export const mkEffectFn10 = function mkEffectFn10(fn) {
   return function(a, b, c, d, e, f, g, h, i, j) {
     return fn(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)();
+  };
+};
+
+export const runEffectFn0 = function runEffectFn0(fn) {
+  return function() {
+    return fn();
   };
 };
 

--- a/src/Effect/Uncurried.purs
+++ b/src/Effect/Uncurried.purs
@@ -133,7 +133,12 @@
 module Effect.Uncurried where
 
 import Data.Monoid (class Monoid, class Semigroup, mempty, (<>))
+import Data.Unit (Unit)
 import Effect (Effect)
+
+foreign import data EffectFn0 :: Type -> Type
+
+type role EffectFn0 representational
 
 foreign import data EffectFn1 :: Type -> Type -> Type
 
@@ -175,6 +180,8 @@ foreign import data EffectFn10 :: Type -> Type -> Type -> Type -> Type -> Type -
 
 type role EffectFn10 representational representational representational representational representational representational representational representational representational representational representational
 
+foreign import mkEffectFn0 :: forall r.
+  (Unit -> Effect r) -> EffectFn0 r
 foreign import mkEffectFn1 :: forall a r.
   (a -> Effect r) -> EffectFn1 a r
 foreign import mkEffectFn2 :: forall a b r.
@@ -196,6 +203,8 @@ foreign import mkEffectFn9 :: forall a b c d e f g h i r.
 foreign import mkEffectFn10 :: forall a b c d e f g h i j r.
   (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Effect r) -> EffectFn10 a b c d e f g h i j r
 
+foreign import runEffectFn0 :: forall r.
+  EffectFn0 r -> Effect r
 foreign import runEffectFn1 :: forall a r.
   EffectFn1 a r -> a -> Effect r
 foreign import runEffectFn2 :: forall a b r.


### PR DESCRIPTION
**Description of the change**

This adds `EffectFn0`, `mkEffectFn0`, and `runEffectFn0`, similar to `Fn0`, `mkFn0`, and `runFn0` from `purescript-functions`.

My motivation for this change is this;

It was very convenient for me to set up minimal FFI bindings to a JS function which returned a record whose values were functions, and I could declare the types of the fields in the return value using `EffectFnX` without needing to write any additional JS.

However, JS functions which took no arguments were typed as `EffectFn1 Unit (Promise _)` and eventually called with `unit`. This had unintended consequences as calling `foo()` vs `foo({})` produced different results.

These functions can now be typed as `EffectFn0 (Promise _)` and called with `Promise.toAffE $ runEffectFn0 f` instead of `Promise.toAffE <<< runEffectFn1 f`.

There isn't a test suite for this package but this appears to work as intended for my use case. I added `mkEffectFn0` for completeness, and tested it with the following:

```purescript
Console.log "Test 1"
runEffectFn0 $ mkEffectFn0 \_ -> Console.log "Test 2"
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
